### PR TITLE
Makefile update for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man/man1
 DOCDIR=$(PREFIX)/share/doc/google-cli
+UNAME_S:=$(shell uname -s)
+
 
 .PHONY: install uninstall
 
@@ -12,9 +14,16 @@ install:
 	install -m755 -d $(MANDIR)
 	install -m755 -d $(DOCDIR)
 	gzip -c googler.1 > googler.1.gz
-	install -m755 -t $(BINDIR) googler
-	install -m644 -t $(MANDIR) googler.1.gz
-	install -m644 -t $(DOCDIR) README.md
+	@if [ "$(UNAME_S)" = "Linux" ]; then\
+		install -m755 -t $(BINDIR) googler; \
+		install -m644 -t $(MANDIR) googler.1.gz; \
+		install -m644 -t $(DOCDIR) README.md; \
+	fi
+	@if [ "$(UNAME_S)" = "Darwin" ]; then\
+		install -m755  googler $(BINDIR); \
+		install -m644  googler.1.gz $(MANDIR); \
+		install -m644  README.md $(DOCDIR); \
+	fi
 	rm -f googler.1.gz
 
 uninstall:


### PR DESCRIPTION
```install``` command on OSX hasn't the same behavior as on Linux.
option ```-t``` doesn't exist.

